### PR TITLE
nom 4.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ name = "nom_bibtex"
 travis-ci = { repository = "charlesvdv/nom-bibtex" }
 
 [dependencies]
-nom = "3.0.*"
+nom = "4.0.0"
 quick-error = "1.2.*"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use nom::Err;
-use nom::types::CompleteByteSlice;
 
 quick_error! {
     #[derive(Debug, PartialEq, Eq)]
@@ -8,29 +7,22 @@ quick_error! {
         Parsing (descr: String) {
             description(descr)
             display(me) -> ("Parsing error. Reason: {}", me.description())
-            // TODO: how can we group the below two?
-            from(err: Err<CompleteByteSlice<'_>>) -> (
-                match err {
-                    Err::Incomplete(e) => format!("Incomplete: {:?}", e),
-                    Err::Error(e) | Err::Failure(e) => e.into_error_kind().description().into(),
-                }
-            )
-            from(err: Err<&[u8]>) -> (
-                match err {
-                    Err::Incomplete(e) => format!("Incomplete: {:?}", e),
-                    Err::Error(e) | Err::Failure(e) => e.into_error_kind().description().into(),
-                }
-            )
-            from(err: Err<&str>) -> (
-                match err {
-                    Err::Incomplete(e) => format!("Incomplete: {:?}", e),
-                    Err::Error(e) | Err::Failure(e) => e.into_error_kind().description().into(),
-                }
-            )
         }
         StringVariableNotFound (var: String) {
             description("String variable not found.")
             display(me) -> ("{}: {}", me.description(), var)
         }
+    }
+}
+
+// We cannot use the from() from quick_error, because we need to put lifetimes that we didn't
+// define.
+impl<T> From<Err<T>> for BibtexError {
+    fn from(err: Err<T>) -> BibtexError {
+        let descr = match err {
+            Err::Incomplete(e) => format!("Incomplete: {:?}", e),
+            Err::Error(e) | Err::Failure(e) => e.into_error_kind().description().into(),
+        };
+        BibtexError::Parsing(descr)
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,7 @@
 use std::str;
 use error::BibtexError;
 use std::result;
+use nom::types::CompleteByteSlice;
 use parser;
 use parser::Entry;
 
@@ -51,8 +52,8 @@ impl<'a> Bibtex<'a> {
 
     /// Get a raw vector of entries in order from the files.
     pub fn raw_parse(bibtex: &'a str) -> Result<Vec<Entry<'a>>> {
-        match parser::entries(bibtex.as_bytes()).to_full_result() {
-            Ok(v) => Ok(v),
+        match parser::entries(CompleteByteSlice(bibtex.as_bytes())) {
+            Ok((_, v)) => Ok(v),
             Err(e) => Err(From::from(e)),
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,7 +7,8 @@
 // #![allow(dead_code)]
 //
 use std::str;
-use nom::{alpha, is_digit, ErrorKind, IResult};
+use nom::{alpha, is_digit, ErrorKind, IResult, Err};
+use nom::types::CompleteByteSlice;
 use model::{KeyValue, StringValueType};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -18,14 +19,14 @@ pub enum Entry<'a> {
     Bibliography(&'a str, &'a str, Vec<KeyValue<'a>>),
 }
 
-named!(pub entries<Vec<Entry>>,
+named!(pub entries<CompleteByteSlice, Vec<Entry>>,
     many1!(entry)
 );
 
 /// Parse any entry in a bibtex file.
 /// A good entry normally starts with a @ otherwise, it's
 /// considered as a comment.
-named!(pub entry<Entry>,
+named!(pub entry<CompleteByteSlice, Entry>,
     ws!(
         alt!(
             do_parse!(
@@ -41,21 +42,25 @@ named!(pub entry<Entry>,
 );
 
 /// Handle data beginning without an @ which are considered comments.
-named!(no_type_comment<&str>,
+named!(no_type_comment<CompleteByteSlice, &str>,
     map!(
-        map_res!(alt!(
-                take_until!("@") |
-                call!(take_until_end)),
-            str::from_utf8),
+        map_res!(
+            is_not!("@"),
+            complete_byte_slice_to_str
+        ),
         str::trim
     )
 );
 
-/// Parse any entry which starts with a @.
-fn entry_with_type<'a>(input: &'a [u8]) -> IResult<&'a [u8], Entry> {
-    let entry_type = peeked_entry_type(input).to_full_result().unwrap();
+fn complete_byte_slice_to_str<'a>(s: CompleteByteSlice<'a>) -> Result<&'a str, str::Utf8Error> {
+    str::from_utf8(s.0)
+}
 
-    match entry_type.to_lowercase().as_ref() {
+/// Parse any entry which starts with a @.
+fn entry_with_type<'a>(input: CompleteByteSlice<'a>) -> IResult<CompleteByteSlice<'a>, Entry> {
+    let entry_type = peeked_entry_type(input).unwrap();
+
+    match entry_type.1.to_lowercase().as_ref() {
         "comment" => type_comment(input),
         "string" => variable(input),
         "preamble" => preamble(input),
@@ -65,7 +70,7 @@ fn entry_with_type<'a>(input: &'a [u8]) -> IResult<&'a [u8], Entry> {
 
 /// Handle a comment of the format:
 /// @Comment { my comment }
-named!(type_comment<Entry>, do_parse!(
+named!(type_comment<CompleteByteSlice, Entry>, do_parse!(
     entry_type >>
     comment: call!(bracketed_string) >>
     (Entry::Comment(comment))
@@ -73,7 +78,7 @@ named!(type_comment<Entry>, do_parse!(
 
 /// Handle a preamble of the format:
 /// @Preamble { my preamble }
-named!(preamble<Entry>, do_parse!(
+named!(preamble<CompleteByteSlice, Entry>, do_parse!(
     entry_type >>
     ws!(char!('{')) >>
     preamble: alt!(
@@ -85,7 +90,7 @@ named!(preamble<Entry>, do_parse!(
             (val)
         ) |
         map!(
-            map!(map_res!(take_until!("}"), str::from_utf8), str::trim),
+            map!(map_res!(take_until!("}"), complete_byte_slice_to_str), str::trim),
             |v| vec![StringValueType::Str(v)]
         )
     ) >>
@@ -95,7 +100,7 @@ named!(preamble<Entry>, do_parse!(
 
 /// Handle a string variable from the bibtex format:
 /// @String (key = "value") or @String {key = "value"}
-named!(variable<Entry>, do_parse!(
+named!(variable<CompleteByteSlice, Entry>, do_parse!(
     entry_type >>
     key_val: call!(handle_variable) >>
     alt!(char!('}') | char!(')')) >>
@@ -103,7 +108,7 @@ named!(variable<Entry>, do_parse!(
 ));
 
 /// String variable can be delimited by brackets or parenthesis.
-named!(handle_variable<KeyValue>,
+named!(handle_variable<CompleteByteSlice, KeyValue>,
     ws!(
         alt!(
            delimited!(
@@ -121,10 +126,10 @@ named!(handle_variable<KeyValue>,
 
 /// Parse key value pair which has the form:
 /// key="value"
-named!(variable_key_value_pair<KeyValue>,
+named!(variable_key_value_pair<CompleteByteSlice, KeyValue>,
     map!(
         separated_pair!(
-            map_res!(call!(alpha), str::from_utf8),
+            map_res!(call!(alpha), complete_byte_slice_to_str),
             ws!(char!('=')),
             alt_complete!(
                 map!(call!(quoted_string), |v| vec![StringValueType::Str(v)]) |
@@ -132,7 +137,7 @@ named!(variable_key_value_pair<KeyValue>,
                 call!(abbreviation_only)
             )
         ),
-        |v: (&'a str, Vec<StringValueType<'a>>)| KeyValue::new(v.0, v.1)
+        |v: (&str, Vec<StringValueType<'_>>)| KeyValue::new(v.0, v.1)
     )
 );
 
@@ -141,10 +146,10 @@ named!(variable_key_value_pair<KeyValue>,
 ///     tag1,
 ///     tag2
 /// }
-named!(pub bibliography_entry<Entry>, do_parse!(
+named!(pub bibliography_entry<CompleteByteSlice, Entry>, do_parse!(
     entry_t: entry_type >>
     ws!(char!('{')) >>
-    citation_key: ws!(map_res!(take_until_and_consume!(","), str::from_utf8)) >>
+    citation_key: ws!(map_res!(take_until_and_consume!(","), complete_byte_slice_to_str)) >>
     tags: bib_tags >>
     opt!(ws!(tag!(","))) >>
     ws!(char!('}')) >>
@@ -152,26 +157,26 @@ named!(pub bibliography_entry<Entry>, do_parse!(
 ));
 
 /// Parse all the tags used by one bibliography entry separated by a comma.
-named!(bib_tags<Vec<KeyValue<'a>>>,
+named!(bib_tags<CompleteByteSlice, Vec<KeyValue<'_>>>,
     separated_list!(
         ws!(char!(',')),
         map!(
             separated_pair!(
                 // The key.
-                map_res!(call!(alpha), str::from_utf8),
+                map_res!(call!(alpha), complete_byte_slice_to_str),
                 ws!(char!('=')),
                 alt_complete!(
                     call!(abbreviation_string) |
                     map!(call!(quoted_string), |v| vec![StringValueType::Str(v)]) |
                     map!(call!(bracketed_string), |v| vec![StringValueType::Str(v)]) |
                     map!(
-                        map_res!(take_while1!(is_digit), str::from_utf8),
+                        map_res!(take_while1!(is_digit), complete_byte_slice_to_str),
                         |v| vec![StringValueType::Str(v)]
                     ) |
                     call!(abbreviation_only)
                 )
             ),
-            |v: (&'a str, Vec<StringValueType<'a>>)| KeyValue::new(v.0, v.1)
+            |v: (&str, Vec<StringValueType<'_>>)| KeyValue::new(v.0, v.1)
         )
     )
 );
@@ -180,10 +185,10 @@ named!(bib_tags<Vec<KeyValue<'a>>>,
 /// @type{ ...
 ///
 /// But don't consume the last bracket.
-named!(entry_type<&str>,
+named!(entry_type<CompleteByteSlice, &str>,
     delimited!(
         char!('@'),
-        map_res!(ws!(alpha), str::from_utf8),
+        map_res!(ws!(alpha), complete_byte_slice_to_str),
         peek!(
             alt!(
                 char!('{') |
@@ -197,31 +202,32 @@ named!(entry_type<&str>,
 
 /// Same as entry_type but with peek so it doesn't consume the
 /// entry type.
-named!(peeked_entry_type<&str>,
+named!(peeked_entry_type<CompleteByteSlice, &str>,
     peek!(
         entry_type
     )
 );
 
-named!(abbreviation_string<Vec<StringValueType>>,
+named!(abbreviation_string<CompleteByteSlice, Vec<StringValueType>>,
     complete!(separated_nonempty_list!(
         ws!(char!('#')),
         alt!(
-            map!(map_res!(call!(alpha), str::from_utf8), |v| StringValueType::Abbreviation(v)) |
+            map!(map_res!(call!(alpha), complete_byte_slice_to_str), |v| StringValueType::Abbreviation(v)) |
             map!(call!(quoted_string), |v| StringValueType::Str(v))
         )
     ))
 );
 
-named!(abbreviation_only<Vec<StringValueType>>,
-    ws!(map!(map_res!(call!(alpha), str::from_utf8), |v| vec![StringValueType::Abbreviation(v)]))
+named!(abbreviation_only<CompleteByteSlice, Vec<StringValueType>>,
+    ws!(map!(map_res!(call!(alpha), complete_byte_slice_to_str), |v| vec![StringValueType::Abbreviation(v)]))
 );
 
 /// Only used for bibliography tags.
-fn bracketed_string<'a>(input: &'a [u8]) -> IResult<&'a [u8], &str> {
+fn bracketed_string<'a>(input: CompleteByteSlice<'a>) -> IResult<CompleteByteSlice<'a>, &str> {
+    let input = &input;
     // We are not in a bracketed_string.
     if input[0] as char != '{' {
-        return IResult::Error(ErrorKind::Custom(0));
+        return Err(Err::Error(error_position!(CompleteByteSlice(input), ErrorKind::Custom(0))));
     }
     let mut brackets_queue = 0;
 
@@ -236,19 +242,20 @@ fn bracketed_string<'a>(input: &'a [u8]) -> IResult<&'a [u8], &str> {
                 brackets_queue -= 1;
             },
             '"' => if brackets_queue == 0 {
-                return IResult::Error(ErrorKind::Custom(0));
+                return Err(Err::Error(error_position!(CompleteByteSlice(input), ErrorKind::Custom(0))));
             },
-            '@' => return IResult::Error(ErrorKind::Custom(0)),
+            '@' => return Err(Err::Error(error_position!(CompleteByteSlice(input), ErrorKind::Custom(0)))),
             _ => continue,
         }
     }
     let value = str::from_utf8(&input[1..i]).expect("Unable to parse char sequence");
-    IResult::Done(&input[i + 1..], str::trim(value))
+    Ok((CompleteByteSlice(&input[i + 1..]), str::trim(value)))
 }
 
-fn quoted_string<'a>(input: &'a [u8]) -> IResult<&'a [u8], &str> {
+fn quoted_string<'a>(input: CompleteByteSlice<'a>) -> IResult<CompleteByteSlice<'a>, &str> {
+    let input = input.as_ref();
     if input[0] as char != '"' {
-        return IResult::Error(ErrorKind::Custom(0));
+        return Err(Err::Error(error_position!(CompleteByteSlice(input), ErrorKind::Custom(0))));
     }
 
     let mut brackets_queue = 0;
@@ -260,7 +267,7 @@ fn quoted_string<'a>(input: &'a [u8]) -> IResult<&'a [u8], &str> {
             '}' => {
                 brackets_queue -= 1;
                 if brackets_queue < 0 {
-                    return IResult::Error(ErrorKind::Custom(0));
+                    return Err(Err::Error(error_position!(CompleteByteSlice(input), ErrorKind::Custom(0))));
                 }
             }
             '"' => if brackets_queue == 0 {
@@ -270,12 +277,8 @@ fn quoted_string<'a>(input: &'a [u8]) -> IResult<&'a [u8], &str> {
         }
     }
     let value = str::from_utf8(&input[1..i]).expect("Unable to parse char sequence");
-    IResult::Done(&input[i + 1..], value)
+    Ok((CompleteByteSlice(&input[i + 1..]), value))
 }
-
-named!(take_until_end,
-    take_while!(call!(|c| c != '\0' as u8))
-);
 
 #[cfg(test)]
 mod tests {
@@ -284,19 +287,18 @@ mod tests {
     // Relevant nom issue: https://github.com/Geal/nom/issues/505
 
     use super::*;
-    use nom::IResult;
 
     #[test]
     fn test_entry() {
         assert_eq!(
-            entry(b" comment"),
-            IResult::Done(&b""[..], Entry::Comment("comment"))
+            entry(CompleteByteSlice(b" comment")),
+            Ok((CompleteByteSlice(b""), Entry::Comment("comment")))
         );
 
         let kv = KeyValue::new("key", vec![StringValueType::Str("value")]);
         assert_eq!(
-            entry(b" @ StrIng { key = \"value\" }"),
-            IResult::Done(&b""[..], Entry::Variable(kv))
+            entry(CompleteByteSlice(b" @ StrIng { key = \"value\" }")),
+            Ok((CompleteByteSlice(b""), Entry::Variable(kv)))
         );
 
         let bib_str = b"@misc{ patashnik-bibtexing,
@@ -310,38 +312,38 @@ mod tests {
             KeyValue::new("year", vec![StringValueType::Str("1988")])
         ];
         assert_eq!(
-            entry_with_type(bib_str),
-            IResult::Done(&b""[..], Entry::Bibliography("misc", "patashnik-bibtexing", tags))
+            entry_with_type(CompleteByteSlice(bib_str)),
+            Ok((CompleteByteSlice(b""), Entry::Bibliography("misc", "patashnik-bibtexing", tags)))
         );
     }
 
     #[test]
     fn test_no_type_comment() {
-        assert_eq!(no_type_comment(b"test@"),
-        IResult::Done(&b"@"[..], "test"));
-        assert_eq!(no_type_comment(b"test"),
-        IResult::Done(&b""[..], "test"));
+        assert_eq!(no_type_comment(CompleteByteSlice(b"test@")),
+        Ok((CompleteByteSlice(b"@"), "test")));
+        assert_eq!(no_type_comment(CompleteByteSlice(b"test")),
+        Ok((CompleteByteSlice(b""), "test")));
     }
 
     #[test]
     fn test_entry_with_type() {
         assert_eq!(
-            entry_with_type(b"@Comment{test}"),
-            IResult::Done(&b""[..], Entry::Comment("test"))
+            entry_with_type(CompleteByteSlice(b"@Comment{test}")),
+            Ok((CompleteByteSlice(b""), Entry::Comment("test")))
         );
 
         let kv = KeyValue::new("key", vec![StringValueType::Str("value")]);
         assert_eq!(
-            entry_with_type(b"@String{key=\"value\"}"),
-            IResult::Done(&b""[..], Entry::Variable(kv))
+            entry_with_type(CompleteByteSlice(b"@String{key=\"value\"}")),
+            Ok((CompleteByteSlice(b""), Entry::Variable(kv)))
         );
 
         assert_eq!(
-            entry_with_type(b"@preamble{name # \"'s preamble\"}"),
-            IResult::Done(&b""[..], Entry::Preamble(vec![
+            entry_with_type(CompleteByteSlice(b"@preamble{name # \"'s preamble\"}")),
+            Ok((CompleteByteSlice(b""), Entry::Preamble(vec![
                 StringValueType::Abbreviation("name"),
                 StringValueType::Str("'s preamble")
-            ]))
+            ])))
         );
 
         let bib_str = b"@misc{ patashnik-bibtexing,
@@ -355,24 +357,24 @@ mod tests {
             KeyValue::new("year", vec![StringValueType::Str("1988")])
         ];
         assert_eq!(
-            entry_with_type(bib_str),
-            IResult::Done(&b""[..], Entry::Bibliography("misc", "patashnik-bibtexing", tags))
+            entry_with_type(CompleteByteSlice(bib_str)),
+            Ok((CompleteByteSlice(b""), Entry::Bibliography("misc", "patashnik-bibtexing", tags)))
         );
     }
 
     #[test]
     fn test_type_comment() {
-        assert_eq!(type_comment(b"@Comment{test}"),
-        IResult::Done(&b""[..], Entry::Comment("test")));
+        assert_eq!(type_comment(CompleteByteSlice(b"@Comment{test}")),
+        Ok((CompleteByteSlice(b""), Entry::Comment("test"))));
     }
 
     #[test]
     fn test_preamble() {
-        assert_eq!(preamble(b"@preamble{my preamble}"),
-                   IResult::Done(&b""[..],
+        assert_eq!(preamble(CompleteByteSlice(b"@preamble{my preamble}")),
+                   Ok((CompleteByteSlice(b""),
                                  Entry::Preamble(
                                      vec![StringValueType::Str("my preamble")]
-                                 ))
+                                 )))
         );
     }
 
@@ -388,14 +390,14 @@ mod tests {
             ],
         );
 
-        assert_eq!(variable(b"@string{key=\"value\"}"),
-        IResult::Done(&b""[..], Entry::Variable(kv1)));
+        assert_eq!(variable(CompleteByteSlice(b"@string{key=\"value\"}")),
+        Ok((CompleteByteSlice(b""), Entry::Variable(kv1))));
 
-        assert_eq!(variable(b"@string( key=\"value\" )"),
-        IResult::Done(&b""[..], Entry::Variable(kv2)));
+        assert_eq!(variable(CompleteByteSlice(b"@string( key=\"value\" )")),
+        Ok((CompleteByteSlice(b""), Entry::Variable(kv2))));
 
-        assert_eq!(variable(b"@string( key=varone # vartwo)"),
-        IResult::Done(&b""[..], Entry::Variable(kv3)));
+        assert_eq!(variable(CompleteByteSlice(b"@string( key=varone # vartwo)")),
+        Ok((CompleteByteSlice(b""), Entry::Variable(kv3))));
     }
 
     #[test]
@@ -409,8 +411,8 @@ mod tests {
         );
 
         assert_eq!(
-            variable_key_value_pair(b"key = varone # vartwo,"),
-            IResult::Done(&b","[..], kv)
+            variable_key_value_pair(CompleteByteSlice(b"key = varone # vartwo,")),
+            Ok((CompleteByteSlice(b","), kv))
         );
     }
 
@@ -427,11 +429,11 @@ mod tests {
              KeyValue::new("year", vec![StringValueType::Str("1988")])
         ];
         assert_eq!(
-            bibliography_entry(bib_str),
-            IResult::Done(
-                &b""[..],
+            bibliography_entry(CompleteByteSlice(bib_str)),
+            Ok((
+                CompleteByteSlice(b""),
                 Entry::Bibliography("misc", "patashnik-bibtexing", tags)
-            )
+            ))
         );
     }
 
@@ -457,66 +459,66 @@ mod tests {
                               StringValueType::Str("My new book")
                           ]),
         ];
-        assert_eq!(bib_tags(tags_str), IResult::Done(&b"}"[..], result));
+        assert_eq!(bib_tags(CompleteByteSlice(tags_str)), Ok((CompleteByteSlice(b"}"), result)));
     }
 
     #[test]
     fn test_entry_type() {
-        assert_eq!(entry_type(b"@misc{"),
-        IResult::Done(&b"{"[..], "misc"));
+        assert_eq!(entry_type(CompleteByteSlice(b"@misc{")),
+        Ok((CompleteByteSlice(b"{"), "misc")));
 
-        assert_eq!(entry_type(b"@ misc {"),
-        IResult::Done(&b"{"[..], "misc"));
+        assert_eq!(entry_type(CompleteByteSlice(b"@ misc {")),
+        Ok((CompleteByteSlice(b"{"), "misc")));
 
-        assert_eq!(entry_type(b"@string("),
-        IResult::Done(&b"("[..], "string"));
+        assert_eq!(entry_type(CompleteByteSlice(b"@string(")),
+        Ok((CompleteByteSlice(b"("), "string")));
     }
 
     #[test]
     fn test_abbreviation_string() {
-        assert_eq!(abbreviation_string(b"var # \"string\","),
-                   IResult::Done(&b","[..], vec![
+        assert_eq!(abbreviation_string(CompleteByteSlice(b"var # \"string\",")),
+                   Ok((CompleteByteSlice(b","), vec![
                        StringValueType::Abbreviation("var"),
                        StringValueType::Str("string"),
-                   ])
+                   ]))
         );
-        assert_eq!(abbreviation_string(b"\"string\" # var,"),
-                   IResult::Done(&b","[..], vec![
+        assert_eq!(abbreviation_string(CompleteByteSlice(b"\"string\" # var,")),
+                   Ok((CompleteByteSlice(b","), vec![
                        StringValueType::Str("string"),
                        StringValueType::Abbreviation("var"),
-                   ])
+                   ]))
         );
-        assert_eq!(abbreviation_string(b"string # var,"),
-                   IResult::Done(&b","[..], vec![
+        assert_eq!(abbreviation_string(CompleteByteSlice(b"string # var,")),
+                   Ok((CompleteByteSlice(b","), vec![
                        StringValueType::Abbreviation("string"),
                        StringValueType::Abbreviation("var"),
-                   ])
+                   ]))
         );
     }
 
     #[test]
     fn test_abbreviation_only() {
         assert_eq!(
-            abbreviation_only(b" var "),
-            IResult::Done(&b""[..], vec![StringValueType::Abbreviation("var")])
+            abbreviation_only(CompleteByteSlice(b" var ")),
+            Ok((CompleteByteSlice(b""), vec![StringValueType::Abbreviation("var")]))
         );
     }
 
     #[test]
     fn test_bracketed_string() {
-        assert_eq!(bracketed_string(b"{ test }"), IResult::Done(&b""[..], "test"));
-        assert_eq!(bracketed_string(b"{ {test} }"), IResult::Done(&b""[..], "{test}"));
-        assert!(bracketed_string(b"{ @{test} }").to_full_result().is_err());
+        assert_eq!(bracketed_string(CompleteByteSlice(b"{ test }")), Ok((CompleteByteSlice(b""), "test")));
+        assert_eq!(bracketed_string(CompleteByteSlice(b"{ {test} }")), Ok((CompleteByteSlice(b""), "{test}")));
+        assert!(bracketed_string(CompleteByteSlice(b"{ @{test} }")).is_err());
     }
 
     #[test]
     fn test_quoted_string() {
-        assert_eq!(quoted_string(b"\"test\""), IResult::Done(&b""[..], "test"));
-        assert_eq!(quoted_string(b"\"test \""), IResult::Done(&b""[..], "test "));
-        assert_eq!(quoted_string(b"\"{\"test\"}\""), IResult::Done(&b""[..], "{\"test\"}"));
-        assert_eq!(quoted_string(b"\"A {bunch {of} braces {in}} title\""),
-        IResult::Done(&b""[..], "A {bunch {of} braces {in}} title"));
-        assert_eq!(quoted_string(b"\"Simon {\"}the {saint\"} Templar\""),
-        IResult::Done(&b""[..], "Simon {\"}the {saint\"} Templar"));
+        assert_eq!(quoted_string(CompleteByteSlice(b"\"test\"")), Ok((CompleteByteSlice(b""), "test")));
+        assert_eq!(quoted_string(CompleteByteSlice(b"\"test \"")), Ok((CompleteByteSlice(b""), "test ")));
+        assert_eq!(quoted_string(CompleteByteSlice(b"\"{\"test\"}\"")), Ok((CompleteByteSlice(b""), "{\"test\"}")));
+        assert_eq!(quoted_string(CompleteByteSlice(b"\"A {bunch {of} braces {in}} title\"")),
+        Ok((CompleteByteSlice(b""), "A {bunch {of} braces {in}} title")));
+        assert_eq!(quoted_string(CompleteByteSlice(b"\"Simon {\"}the {saint\"} Templar\"")),
+        Ok((CompleteByteSlice(b""), "Simon {\"}the {saint\"} Templar")));
     }
 }


### PR DESCRIPTION
Holy crap that was heavy. This is the first PR in the series to support #1; I first want to support `nom` 4.0 before moving on.

[Most time was taken by dealing with `Incomplete`](https://github.com/Geal/nom/blob/master/doc/upgrading_to_nom_4.md#dealing-with-incomplete-usage). `nom` 4.0 made Incomplete way more strict. A bunch of things happen there. I am not sure which ones were there in 3.0, and which were not, but I'll drop them here:

- The `ws!()` macro cannot complete on unterminated slices, since it assumes that white space may follow in the stream.
- `no_type_comment` used a custom parsing function that searched for the `\0` byte. I am not sure, but I think this was a C-ism? I moved from `alt!(take_until("@") | take_until_end)` to simply `is_not("@")`. This *does* mean this never terminates on unterminated slices either.

Because of the above two reasons, I decided that the *whole parser* could only reason on `CompleteByteSlice`s. It makes sense for BibTeX, I think, since those are typically "small" files (some kB).

Making everything `CompleteByteSlice`'s takes a tin of code, especially in tests, where almost *everything* needs to get wrapped in that struct. It's a bit sad, but it's how it works for now...

Anyhow, all tests pass. Please take a look at my reasoning, and feel free to hit me up in Brussels/at VUB :-)