### PR TITLE
Upgrade to Nom 5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ name = "nom_bibtex"
 travis-ci = { repository = "charlesvdv/nom-bibtex" }
 
 [dependencies]
-nom = "4.0.0"
+nom = "5.1.0"
 quick-error = "1.2.*"

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,10 +19,23 @@ quick_error! {
 // define.
 impl<T> From<Err<T>> for BibtexError {
     fn from(err: Err<T>) -> BibtexError {
+        unimplemented!();
+        // let descr = match err {
+        //     Err::Incomplete(e) => format!("Incomplete: {:?}", e),
+        //     Err::Error(e) | Err::Failure(e) => e.into_error_kind().description().into(),
+        // };
+        // BibtexError::Parsing(descr)
+    }
+}
+
+/*
+impl BibtexError {
+    pub fn from_with_context<T>(err: Err<T>, context: &'static str) -> BibtexError {
         let descr = match err {
             Err::Incomplete(e) => format!("Incomplete: {:?}", e),
-            Err::Error(e) | Err::Failure(e) => e.into_error_kind().description().into(),
+            Err::Error(e) | Err::Failure(e) => e.add_context().description().into(),
         };
         BibtexError::Parsing(descr)
     }
 }
+*/

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use nom::Err;
+use nom::error::ErrorKind;
 use std::error::Error;
 
 quick_error! {
@@ -17,25 +18,14 @@ quick_error! {
 
 // We cannot use the from() from quick_error, because we need to put lifetimes that we didn't
 // define.
-impl<T> From<Err<T>> for BibtexError {
-    fn from(err: Err<T>) -> BibtexError {
-        unimplemented!();
-        // let descr = match err {
-        //     Err::Incomplete(e) => format!("Incomplete: {:?}", e),
-        //     Err::Error(e) | Err::Failure(e) => e.into_error_kind().description().into(),
-        // };
-        // BibtexError::Parsing(descr)
-    }
-}
-
-/*
-impl BibtexError {
-    pub fn from_with_context<T>(err: Err<T>, context: &'static str) -> BibtexError {
+impl<'a> From<Err<(&str, ErrorKind)>> for BibtexError {
+    fn from(err: Err<(&str, ErrorKind)>) -> BibtexError {
         let descr = match err {
             Err::Incomplete(e) => format!("Incomplete: {:?}", e),
-            Err::Error(e) | Err::Failure(e) => e.add_context().description().into(),
+            Err::Error((_, e)) | Err::Failure((_, e)) => {
+                e.description().into()
+            },
         };
         BibtexError::Parsing(descr)
     }
 }
-*/

--- a/src/model.rs
+++ b/src/model.rs
@@ -51,7 +51,7 @@ impl<'a> Bibtex<'a> {
 
     /// Get a raw vector of entries in order from the files.
     pub fn raw_parse(bibtex: &'a str) -> Result<Vec<Entry<'a>>> {
-        match parser::entries(bibtex.as_bytes()) {
+        match parser::entries(bibtex) {
             Ok((_, v)) => Ok(v),
             Err(e) => Err(From::from(e)),
         }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,4 @@
 use error::BibtexError;
-use nom::types::CompleteByteSlice;
 use parser;
 use parser::Entry;
 use std::result;
@@ -52,7 +51,7 @@ impl<'a> Bibtex<'a> {
 
     /// Get a raw vector of entries in order from the files.
     pub fn raw_parse(bibtex: &'a str) -> Result<Vec<Entry<'a>>> {
-        match parser::entries(CompleteByteSlice(bibtex.as_bytes())) {
+        match parser::entries(bibtex.as_bytes()) {
             Ok((_, v)) => Ok(v),
             Err(e) => Err(From::from(e)),
         }


### PR DESCRIPTION
A bit of a larger PR than the previous ones. Initially, I made this change because I wanted the improved error handling that is included in 5.1. Unfortunately, I couldn't make that work with the `named` macro yet.

The only major change I had to make was avoiding the deprecated `ws` macro. While I was at it, I also replaced `u8` with `str`, I hope there wasn't some good reason for using `u8` originally. If so, I can revert that change :)