### PR TITLE
Fix infinite recursion in BibtexError Display impl

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,11 +7,9 @@ quick_error! {
     #[derive(Debug, PartialEq, Eq)]
     pub enum BibtexError {
         Parsing (descr: String) {
-            description(descr)
             display(me) -> ("Parsing error. Reason: {}", descr)
         }
         StringVariableNotFound (var: String) {
-            description("String variable not found.")
             display(me) -> ("String variable not found: {}", var)
         }
     }


### PR DESCRIPTION
Calling `me.to_string()` from `display(me)` resulted in infinite recursion and overflowed the stack.

```
$ cargo test
[...]
thread 'error::tests::test_display_impls' has overflowed its stack
fatal runtime error: stack overflow
```

This PR removes the recursion to solve the issue, and adds a test case for that (implicit) `Display` impl.

Additionally, since `std::error::Error::description()` has been deprecated, its implementation has also been removed.