### PR TITLE
Replace recursion by loop to parse huge files

### DIFF
--- a/samples/test.bib
+++ b/samples/test.bib
@@ -12,6 +12,7 @@
 @string{ alb = "Albert"}
 @string{ ein = "Einstein"}
 @string(ae = alb # " " # ein)
+@string{alg = "Algebraic "}
 
 @article{einstein,
     author =       ae,
@@ -44,4 +45,11 @@
     title = {Differential geometry of complex vector bundles},
     Author = {Kobayashi, Shoshichi},
     year = {2014},
+}
+
+@book{neukirch1999ant,
+    author = {Neukirch, J{\"u}rgen},
+    title = alg # {Number Theory},
+    year = {1999},
+    publisher = {Springer},
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -360,16 +360,14 @@ def_parser!(entry(input) -> Entry; {
 
 // Parses a whole bibtex file to yield a list of entries
 def_parser!(pub entries(input) -> Vec<Entry>; {
-    if input.fragment().trim().is_empty() {
-        Ok((input, vec!()))
+    let mut data = input;
+    let mut entry_list = vec!();
+    while !data.fragment().trim().is_empty() {
+        let (rest_slice, new_entry) = entry(data)?;
+        entry_list.push(new_entry);
+        data = rest_slice;
     }
-    else {
-        let (rest_slice, new_entry) = entry(input)?;
-        let (remaining_slice, mut rest_entries) = entries(rest_slice)?;
-        // NOTE: O(n) insertions, could cause issues in the future
-        rest_entries.insert(0, new_entry);
-        Ok((remaining_slice, rest_entries))
-    }
+    Ok((data,entry_list))
 });
 
 #[cfg(test)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -200,7 +200,8 @@ def_parser!(pub abbreviation_string(input) -> Vec<StringValueType>; {
         pws!(
             alt((
                 abbreviation_only,
-                map(quoted_string, |v: &str| StringValueType::Str(v.into()))
+                map(quoted_string, |v: &str| StringValueType::Str(v.into())),
+                map(bracketed_string, |v: &str| StringValueType::Str(v.into()))
             ))
         )
     )(input)

--- a/tests/bib.rs
+++ b/tests/bib.rs
@@ -55,3 +55,13 @@ fn test_lowercase() {
         "Differential geometry of complex vector bundles"
     );
 }
+
+#[test]
+fn test_huge_file() {
+    // file borrowed from the CryptoBib project https://cryptobib.di.ens.fr/ as
+    // a realistic example of a huge bibtex file
+    let bib_str = read_file("samples/crypto.bib");
+    let bibtex = Bibtex::parse(&bib_str);
+    // test just that the parsing goes through
+    assert!(bibtex.is_ok());
+}

--- a/tests/bib.rs
+++ b/tests/bib.rs
@@ -65,3 +65,18 @@ fn test_huge_file() {
     // test just that the parsing goes through
     assert!(bibtex.is_ok());
 }
+
+#[test]
+fn test_concat() {
+    let bib_str = read_file("samples/test.bib");
+    let bibtex = Bibtex::parse(&bib_str).unwrap();
+
+    let entry = &bibtex.bibliographies()[4];
+    let tags = entry.tags();
+
+    assert_eq!(entry.citation_key(), "neukirch1999ant");
+    assert_eq!(
+        tags["title"],
+        "Algebraic Number Theory"
+    );
+}


### PR DESCRIPTION
When trying to parse huge bibtex files (e.g. [one](https://cryptobib.di.ens.fr/cryptobib/static/files/crypto.bib) of the [cryptobib](https://cryptobib.di.ens.fr/) files) recursion in the `entries` parser at `src/parser.rs:368:51` exhausts the stack and causes an overflow. Try using e.g. [backtrace_on_stack_overflow](https://docs.rs/backtrace-on-stack-overflow/latest/backtrace_on_stack_overflow/) to verify this.

Example code:
```rust
extern crate nom_bibtex;

use std::fs;
use nom_bibtex::Bibtex;

fn main() {
    unsafe {
        backtrace_on_stack_overflow::enable()
    };
    let filename: &str = "crypto.bib";
    let buf = fs::read_to_string(filename).expect("Couldn't open file");
    let bib = Bibtex::parse(buf.as_str()).unwrap(); // <-- HERE
    println!("{:?}", bib); // or something
}
```
Using a loop instead resolves this issue (see diff). This also removes the need for the `O(n)` insert operation because the entries are parsed in the original order instead of reversed, so push can be used.