### PR TITLE
Update to rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["bibtex", "latex", "parser", "nom"]
 repository = "https://github.com/charlesvdv/nom-bibtex"
 documentation = "https://docs.rs/nom-bibtex"
 
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use crate::parser::Span;
-use nom::error::ErrorKind;
 use nom::Err;
-use nom_language::error::{convert_error, VerboseError};
+use nom::error::ErrorKind;
+use nom_language::error::{VerboseError, convert_error};
 use quick_error::quick_error;
 
 quick_error! {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,6 @@
 use crate::error::BibtexError;
 use crate::parser;
-use crate::parser::{mkspan, Entry, Span};
+use crate::parser::{Entry, Span, mkspan};
 use nom_language::error::VerboseError;
 use std::collections::HashMap;
 use std::result;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -25,7 +25,7 @@ use nom_tracable::TracableInfo;
 use std::num::NonZeroUsize;
 use std::str;
 
-const NEEDED_ONE: nom::Needed = nom::Needed::Size(unsafe { NonZeroUsize::new_unchecked(1) });
+const NEEDED_ONE: nom::Needed = nom::Needed::Size(NonZeroUsize::new(1).unwrap());
 
 pub type Span<'a> = LocatedSpan<&'a str, TracableInfo>;
 pub fn mkspan(s: &str) -> Span<'_> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,22 +6,22 @@
 // // that macros are use inside of each others..
 //
 use crate::model::{KeyValue, StringValueType};
+use nom::IResult;
 use nom::character::complete::char as _char;
 use nom::error::ParseError;
-use nom::IResult;
 use nom::{
+    AsChar, Parser,
     branch::alt,
     bytes::complete::{is_not, take_until, take_while1},
     character::complete::{digit1, multispace0},
     combinator::{map, opt, peek},
     multi::{separated_list0, separated_list1},
     sequence::{delimited, preceded, separated_pair},
-    AsChar, Parser,
 };
 use nom_locate::LocatedSpan;
+use nom_tracable::TracableInfo;
 #[cfg(feature = "trace")]
 use nom_tracable::tracable_parser;
-use nom_tracable::TracableInfo;
 use std::num::NonZeroUsize;
 use std::str;
 


### PR DESCRIPTION
In between this PR and https://github.com/charlesvdv/nom-bibtex/pull/30 all clippy lints should be fixed.